### PR TITLE
Removing old command for the docker

### DIFF
--- a/versioned_docs/version-v1.92/node/using-docker.md
+++ b/versioned_docs/version-v1.92/node/using-docker.md
@@ -199,16 +199,6 @@ cp -r $HOME/.hoprd-db-bogota $HOME/.hoprd-db-monte-rosa
 cp -r $HOME/.hoprd-db-bogota/.hopr-id-bogota $HOME/.hoprd-db-monte-rosa/.hopr-id-monte-rosa
 ```
 
-### Using the new command with the old file locations
-
-Following the above example of migration from Bogota to Monte Rosa, you would just use the new Monte Rosa command with the old directories/location: `$HOME/.hoprd-db-bogota/.hopr-id-bogota`
-
-```bash
-docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-bogota:/app/hoprd-db -p 9091:9091/tcp -p 9091:9091/udp -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:1.92.12 --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-bogota --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
-```
-
-This also works fine as long as the other flags and details remain the same.
-
 ## Default ports
 
 - 3000 on TCP : Admin UI port (speaks HTTP protocol)


### PR DESCRIPTION
Removing command with the old DB, we want to get rid off the city names, because we have moved to versioning only.